### PR TITLE
Using SDK's New Promise Design

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -193,12 +193,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nexcess/nexcess-php-sdk.git",
-                "reference": "52c66ee952a75e4e2859a19b37d91d86671be13a"
+                "reference": "89f446c16cf612f2e8e13be334af84816b120121"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nexcess/nexcess-php-sdk/zipball/52c66ee952a75e4e2859a19b37d91d86671be13a",
-                "reference": "52c66ee952a75e4e2859a19b37d91d86671be13a",
+                "url": "https://api.github.com/repos/nexcess/nexcess-php-sdk/zipball/89f446c16cf612f2e8e13be334af84816b120121",
+                "reference": "89f446c16cf612f2e8e13be334af84816b120121",
                 "shasum": ""
             },
             "require": {
@@ -238,7 +238,7 @@
                 "source": "https://github.com/nexcess/nexcess-php-sdk/tree/master",
                 "issues": "https://github.com/nexcess/nexcess-php-sdk/issues"
             },
-            "time": "2018-11-01T16:18:49+00:00"
+            "time": "2018-11-05T13:29:54+00:00"
         },
         {
             "name": "php-enspired/exceptable",

--- a/src/Command/CloudAccount/Backup/Create.php
+++ b/src/Command/CloudAccount/Backup/Create.php
@@ -69,8 +69,6 @@ class Create extends CreateCommand {
       $input->getOption('cloud_account_id'),
       Util::FILTER_INT
     );
-    $download_path = $input->getOption('download');
-    $wait = $input->getOption('wait');
 
     // create backup
     $app->say($this->getPhrase('starting_backup'));
@@ -80,13 +78,14 @@ class Create extends CreateCommand {
     $this->_saySummary($backup->toArray(), $input->getOption('json'));
 
     // wait for backup to complete and then download it?
+    $download_path = $input->getOption('download');
     if (isset($download_path)) {
       $this->_downloadWhenComplete($backup, $download_path);
       return Console::EXIT_SUCCESS;
     }
 
     // wait for backup to complete?
-    if ($wait) {
+    if ($input->getOption('wait')) {
       $this->_waitUntilComplete($backup);
       return Console::EXIT_SUCCESS;
     }

--- a/src/Util/lang/en_US.json
+++ b/src/Util/lang/en_US.json
@@ -24,15 +24,18 @@
           "usage": "cloud-account:backup:list --cloud_account_id 1234"
         },
         "create": {
+          "backup_complete": "Backup complete.\n<info>To download this backup, use:</info>\ncloud-account:backup:download --cloud-account-id {cloud_account_id} \\\n  --filename '{filename}'",
+          "backup_started": "<info>To check on the status of this Backup, use:</info>\ncloud-account:backup:show --cloud-account-id {cloud_account_id} \\\n  --filename '{filename}'",
           "creating":"Creating",
           "created":"Created",
           "desc": "Create a new backup for a given cloud account",
           "downloading": "Downloading backup... ",
-          "download_complete": "download complete:\n  {file}",
+          "download_complete": "Download complete.\n  {filename}",
           "help": "Creates a new backup for a cloud account and optionally downloads it when complete. The given download path must exist and be writable.",
           "opt_cloud_account_id": "Cloud Account ID",
           "opt_download": "Local filesystem path to download backup to",
-          "summary_title": "Backup Created",
+          "starting_backup": "Starting backup...",
+          "summary_title": "Backup started.",
           "summary_key": {
             "complete": "Complete",
             "download_url": "Download URL",
@@ -40,10 +43,11 @@
             "filename": "File Name",
             "filepath": "File Path",
             "filesize": "File Size",
-            "filesize_bytes": "File Size Bytes",
+            "filesize_bytes": "File Size (in bytes)",
             "type": "Type"
           },
-          "usage": "cloud-account:backup:create --cloud_account_id 1234\n  cloud-account:backup:create --cloud_account_id 1234 --download /home/You/Downloads"
+          "usage": "cloud-account:backup:create --cloud_account_id 1234\n  cloud-account:backup:create --cloud_account_id 1234 --download /home/You/Downloads",
+          "waiting": "Waiting for Backup to complete..."
         }
       },
       "create": {


### PR DESCRIPTION
**DEPENDS ON** https://github.com/nexcess/nexcess-php-sdk/pull/34
These changes mean that `$endpoint->createBackup($cloud_account)` will return the new Backup instance directly (not wrapped in a promise).
We will only need the Promise if we want to wait for the backup to complete.

With this new design, `execute` operates like:
- collect input:
  - `cloud_account_id` (int): id of the cloud account to back up
  - `wait` (bool): whether to wait for the backup to complete (implied true if `--download`)
  - `download` (string|null): local filepath to download target dir
- start the backup.
- say the backup summary.
- if downloading:
  - get "when complete" promise
  - add "download" callback
  - wait for promise and callback
  - say filename of downloaded backup
  - **exit 0**
- if just waiting:
  - wait for promise
  - say example cloud-account:backup:download command
  - **exit 0**
- otherwise, not waiting. say example cloud-account:backup:show command
- **exit 0**

## testing
Testing **requires** changes found in https://github.com/nexcess/nexcess-php-sdk/pull/34
Suggest simply checking out that branch and copy+pasting `src/` directory into your `nexcess-cli/vendor/nexcess/nexcess-php-sdk/`.

## results
_backup a cloud account (fire-and-forget)_
```
nexcess-cli$ bin/nexcess-cli cloud-account:backup:create \
  --cloud_account_id 1641 \
  --profile demo2.json

Nexcess-CLI 0.1-alpha
Command Line Interface for the Nexcess.net / Thermo.io API Client
ⓒ 2018 Nexcess.net, LLC

Starting backup...
Backup started.
  File Name: cloud-account.example.com+full-single-Nov.04.2018-19.16.20.tgz
  Complete: true

To check on the status of this Backup, use:
cloud-account:backup:show --cloud-account-id 1641 \
  --filename 'cloud-account.example.com+full-single-Nov.04.2018-20.21.56.tgz'
```

_backup a cloud account and wait for the backup to finish_
```
nexcess-cli$ bin/nexcess-cli cloud-account:backup:create \
  --cloud_account_id 1641 \
  --wait \
  --profile demo2.json

Nexcess-CLI 0.1-alpha
Command Line Interface for the Nexcess.net / Thermo.io API Client
ⓒ 2018 Nexcess.net, LLC

Starting backup...
Backup started.
  File Name: cloud-account.example.com+full-single-Nov.04.2018-19.17.32.tgz
  Complete: true
  
Waiting for Backup to complete...
Backup complete.
To download this Backup, use:
cloud-account:backup:download --cloud-account-id 1641 \
  --filename 'cloud-account.example.com+full-single-Nov.04.2018-19.17.32.tgz'
```

_backup a cloud account and download the backup file when it is ready_
```
nexcess-cli$ bin/nexcess-cli cloud-account:backup:create \
  --cloud_account_id 1641 \
  --download ../tmp \
  --profile demo2.json
  
Nexcess-CLI 0.1-alpha
Command Line Interface for the Nexcess.net / Thermo.io API Client
ⓒ 2018 Nexcess.net, LLC

Starting backup...
Backup started.
  File Name: cloud-account.example.com+full-single-Nov.04.2018-19.19.14.tgz
  Complete: true

Downloading backup... 
Download complete.
  ../tmp/cloud-account.example.com+full-single-Nov.04.2018-19.19.14.tgz
```