### PR TITLE
Upgrade Phan

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+  'directory_list' => ['src', 'vendor'],
+  'exclude_analysis_directory_list' => ['vendor'],
+  'suppress_issue_types' => [
+    // https://github.com/phan/phan/issues/1143
+    'PhanUnanalyzable',
+    // https://github.com/phan/phan/issues/2123
+    'PhanTypeInvalidDimOffset'
+  ]
+];

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ php:
   - 7.1
 before_script:
   - phpenv config-rm xdebug.ini
-  - pecl install ast-0.1.7
+  - pecl install ast
   - composer install --no-scripts --no-suggest
   - vendor/bin/phpcs --config-set installed_paths vendor/nocworx/phpcs/
 script:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^7.0",
-    "phan/phan": "0.8.11",
+    "phan/phan": "^1",
     "nocworx/phpcs": "^1.4"
   },
   "autoload-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bff2939324136fbea9f59832e663f2a7",
+    "content-hash": "b9c19cbcef604143c20d3d561aa894a9",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -193,12 +193,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nexcess/nexcess-php-sdk.git",
-                "reference": "e6977f84d523c1d1ab74eabf3104b2e31c16903f"
+                "reference": "63a38e0923c5ae359479d68542bc1e26cb9724c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nexcess/nexcess-php-sdk/zipball/e6977f84d523c1d1ab74eabf3104b2e31c16903f",
-                "reference": "e6977f84d523c1d1ab74eabf3104b2e31c16903f",
+                "url": "https://api.github.com/repos/nexcess/nexcess-php-sdk/zipball/63a38e0923c5ae359479d68542bc1e26cb9724c9",
+                "reference": "63a38e0923c5ae359479d68542bc1e26cb9724c9",
                 "shasum": ""
             },
             "require": {
@@ -238,7 +238,7 @@
                 "source": "https://github.com/nexcess/nexcess-php-sdk/tree/master",
                 "issues": "https://github.com/nexcess/nexcess-php-sdk/issues"
             },
-            "time": "2018-11-06T02:47:34+00:00"
+            "time": "2018-11-06T13:51:37+00:00"
         },
         {
             "name": "php-enspired/exceptable",
@@ -461,6 +461,112 @@
     ],
     "packages-dev": [
         {
+            "name": "composer/semver",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "c7cb9a2095a074d131b65a8a0cd294479d785573"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/c7cb9a2095a074d131b65a8a0cd294479d785573",
+                "reference": "c7cb9a2095a074d131b65a8a0cd294479d785573",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5 || ^5.0.5",
+                "phpunit/phpunit-mock-objects": "2.3.0 || ^3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "time": "2016-08-30T16:08:34+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "b8e9745fb9b06ea6664d8872c4505fb16df4611c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/b8e9745fb9b06ea6664d8872c4505fb16df4611c",
+                "reference": "b8e9745fb9b06ea6664d8872c4505fb16df4611c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0",
+                "psr/log": "^1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "time": "2018-08-31T19:07:57+00:00"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "1.1.0",
             "source": {
@@ -557,16 +663,16 @@
         },
         {
             "name": "microsoft/tolerant-php-parser",
-            "version": "v0.0.8",
+            "version": "v0.0.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Microsoft/tolerant-php-parser.git",
-                "reference": "10e901a6086826376c6256954dc8903ef0ec6c9e"
+                "reference": "54a84f1250dcde5641e86b5e966fec5f0e201f71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Microsoft/tolerant-php-parser/zipball/10e901a6086826376c6256954dc8903ef0ec6c9e",
-                "reference": "10e901a6086826376c6256954dc8903ef0ec6c9e",
+                "url": "https://api.github.com/repos/Microsoft/tolerant-php-parser/zipball/54a84f1250dcde5641e86b5e966fec5f0e201f71",
+                "reference": "54a84f1250dcde5641e86b5e966fec5f0e201f71",
                 "shasum": ""
             },
             "require": {
@@ -594,7 +700,7 @@
                 }
             ],
             "description": "Tolerant PHP-to-AST parser designed for IDE usage scenarios",
-            "time": "2017-11-17T17:06:43+00:00"
+            "time": "2018-09-26T05:43:26+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -770,29 +876,35 @@
         },
         {
             "name": "phan/phan",
-            "version": "0.8.11",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phan/phan.git",
-                "reference": "576643422b4b36434091c190f82c929befc25f71"
+                "reference": "ca5795c5dd8d379da834c293601fd51085d7708b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phan/phan/zipball/576643422b4b36434091c190f82c929befc25f71",
-                "reference": "576643422b4b36434091c190f82c929befc25f71",
+                "url": "https://api.github.com/repos/phan/phan/zipball/ca5795c5dd8d379da834c293601fd51085d7708b",
+                "reference": "ca5795c5dd8d379da834c293601fd51085d7708b",
                 "shasum": ""
             },
             "require": {
-                "ext-ast": "^0.1.5",
-                "felixfbecker/advanced-json-rpc": "^3.0",
-                "microsoft/tolerant-php-parser": "0.0.8",
-                "nikic/php-parser": "~3.1.1",
-                "php": "~7.0.0 || ~7.1.0 || ~7.2.0",
+                "composer/semver": "^1.4",
+                "composer/xdebug-handler": "^1.3",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "felixfbecker/advanced-json-rpc": "^3.0.3",
+                "microsoft/tolerant-php-parser": "0.0.15",
+                "php": "^7.0.0",
                 "sabre/event": "^5.0",
                 "symfony/console": "^2.3|^3.0|~4.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^6.3.0"
+            },
+            "suggest": {
+                "ext-ast": "Needed for parsing ASTs (unless --use-fallback-parser is used). php-ast ^0.1.5|^1.0.0 is needed.",
+                "ext-tokenizer": "Needed for non-AST support and file/line-based suppressions."
             },
             "bin": [
                 "phan",
@@ -826,7 +938,7 @@
                 "php",
                 "static"
             ],
-            "time": "2018-01-20T21:48:01+00:00"
+            "time": "2018-11-06T01:31:40+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1480,6 +1592,53 @@
                 "xunit"
             ],
             "time": "2018-10-23T05:57:41+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2016-10-10T12:19:37+00:00"
         },
         {
             "name": "sabre/event",

--- a/src/Command/CloudAccount/Backup/ShowList.php
+++ b/src/Command/CloudAccount/Backup/ShowList.php
@@ -13,22 +13,19 @@ use DateTimeImmutable;
 
 use Nexcess\Sdk\ {
   Resource\CloudAccount\Endpoint,
-  Resource\CloudAccount\Backup,
+  Resource\CloudAccount\Entity as CloudAccount,
   Util\Util
 };
 
 use Nexcess\Sdk\Cli\ {
   Console,
-  ConsoleException,
   Command\ShowList as ShowListCommand
 };
 
 use Symfony\Component\Console\ {
-  Input\InputArgument as Arg,
   Input\InputInterface as Input,
   Input\InputOption as Opt,
-  Output\OutputInterface as Output,
-  Helper\Table
+  Output\OutputInterface as Output
 };
 
 /**
@@ -58,15 +55,17 @@ class ShowList extends ShowListCommand {
       Util::FILTER_INT
     );
 
+    $endpoint = $this->_getEndpoint();
+    assert($endpoint instanceof Endpoint);
+    $cloud = $endpoint->retrieve($cloud_id);
+    assert($cloud instanceof CloudAccount);
+
     $this->_saySummary(
-      $this->_getEndpoint()->getBackups(
-        $this->_getEndpoint()->retrieve($cloud_id)
-      )->toArray(true),
-      $input->getOption('json'),
-      $output
+      $endpoint->getBackups($cloud)->toArray(),
+      $input->getOption('json')
     );
 
-    $this->getApplication()->say($this->getPhrase('done'));
+    $this->getConsole()->say($this->getPhrase('done'));
 
     return Console::EXIT_SUCCESS;
   }

--- a/src/Command/CloudAccount/Show.php
+++ b/src/Command/CloudAccount/Show.php
@@ -19,7 +19,6 @@ use Nexcess\Sdk\ {
 use Nexcess\Sdk\Cli\Command\Show as ShowCommand;
 
 use Symfony\Component\Console\ {
-  Input\InputArgument as Arg,
   Input\InputInterface as Input,
   Input\InputOption as Opt,
   Output\OutputInterface as Output

--- a/src/Command/Command.php
+++ b/src/Command/Command.php
@@ -11,16 +11,16 @@ namespace Nexcess\Sdk\Cli\Command;
 
 use Nexcess\Sdk\ {
   Resource\Readable as Endpoint,
-  Resource\Modelable as Model,
   Util\Util
 };
+
 use Nexcess\Sdk\Cli\ {
   Console,
   ConsoleException
 };
+
 use Symfony\Component\Console\ {
   Command\Command as SymfonyCommand,
-  Helper\QuestionHelper,
   Input\InputArgument as Arg,
   Input\InputInterface as Input,
   Input\InputOption as Opt,
@@ -80,6 +80,15 @@ abstract class Command extends SymfonyCommand {
   }
 
   /**
+   * Gets the Console.
+   *
+   * @return Console
+   */
+  public function getConsole() : Console {
+    return $this->getConsole();
+  }
+
+  /**
    * Gets a translated phrase for this command.
    *
    * @param string $key Translation key (without base part)
@@ -87,7 +96,7 @@ abstract class Command extends SymfonyCommand {
    * @return string Translated phrase on success; untranslated key otherwise
    */
   public function getPhrase(string $key, array $context = []) : string {
-    $console = $this->getApplication();
+    $console = $this->getConsole();
     if ($console === null) {
       return $key;
     }
@@ -104,7 +113,7 @@ abstract class Command extends SymfonyCommand {
   public function isEnabled() {
     return empty(static::RESTRICT_TO) ||
       in_array(
-        $this->getApplication()->getConfig()::COMPANY,
+        $this->getConsole()->getConfig()::COMPANY,
         static::RESTRICT_TO
       );
   }
@@ -114,7 +123,7 @@ abstract class Command extends SymfonyCommand {
    * Ensure application has most recent I/O.
    */
   public function run(Input $input, Output $output) {
-    $this->getApplication()->setIO($input, $output);
+    $this->getConsole()->setIO($input, $output);
     return parent::run($input, $output);
   }
 
@@ -228,13 +237,22 @@ abstract class Command extends SymfonyCommand {
   /**
    * Gets an API Endpoint instance.
    *
+   * Note, this method hints it returns "Endpoint",
+   * but the returned Endpoint should often be a specific subclass.
+   * In these cases, to avoid confusing static analysis tools,
+   * always assert() the Endpoint returned is of the expected subclass:
+   * @example <code><?php
+   *    $endpoint = $this->_getEndpoint();
+   *    assert($endpoint instanceof ExpectedEndpointSubclass);
+   *  </code>
+   *
    * @param string|null $endpoint Name of desired endpoint; omit for default
    * @return Endpoint Requested endpoint on success
-   * @throw ConsoleException On failure
+   * @throws ConsoleException On failure
    */
   protected function _getEndpoint(string $endpoint = null) : Endpoint {
     $endpoint = $endpoint ?? static::ENDPOINT;
-    return $this->getApplication()->getClient()->getEndpoint($endpoint);
+    return $this->getConsole()->getClient()->getEndpoint($endpoint);
   }
 
   /**
@@ -282,7 +300,7 @@ abstract class Command extends SymfonyCommand {
    */
   protected function _saySummary(array $details, bool $json = false) {
 
-    $console = $this->getApplication();
+    $console = $this->getConsole();
     $summary = $this->_getSummary($details);
 
     if ($json) {

--- a/src/Command/Command.php
+++ b/src/Command/Command.php
@@ -85,7 +85,7 @@ abstract class Command extends SymfonyCommand {
    * @return Console
    */
   public function getConsole() : Console {
-    return $this->getConsole();
+    return $this->getApplication();
   }
 
   /**

--- a/src/Command/Create.php
+++ b/src/Command/Create.php
@@ -11,12 +11,14 @@ namespace Nexcess\Sdk\Cli\Command;
 
 use Nexcess\Sdk\ {
   ApiException,
-  SdkException
+  Resource\Creatable
 };
+
 use Nexcess\Sdk\Cli\ {
   Command\InputCommand,
   Console
 };
+
 use Symfony\Component\Console\ {
   Input\InputInterface as Input,
   Output\OutputInterface as Output
@@ -31,10 +33,11 @@ abstract class Create extends InputCommand {
    * {@inheritDoc}
    */
   public function execute(Input $input, Output $output) {
-    $app = $this->getApplication();
+    $console = $this->getConsole();
     $endpoint = $this->_getEndpoint();
+    assert($endpoint instanceof Creatable);
 
-    $app->say($this->getPhrase('creating'));
+    $console->say($this->getPhrase('creating'));
 
     try {
       $model = $endpoint->create($this->getInput());
@@ -42,22 +45,14 @@ abstract class Create extends InputCommand {
       switch ($e->getCode()) {
         case ApiException::CREATE_FAILED:
           // @todo Open a support ticket?
-          $app->say($this->getPhrase('failed', ['id' => $model->getId()]));
+          $console->say($this->getPhrase('failed'));
           return Console::EXIT_API_ERROR;
-        default:
-          throw $e;
-      }
-    } catch (SdkException $e) {
-      switch ($e->getCode()) {
-        case SdkException::WAIT_TIMEOUT_EXCEEDED:
-          $app->say($this->getPhrase('timed_out', ['id' => $model->getId()]));
-          return Console::EXIT_SDK_ERROR;
         default:
           throw $e;
       }
     }
 
-    $app->say($this->getPhrase('created', ['id' => $model->getId()]));
+    $console->say($this->getPhrase('created', ['id' => $model->getId()]));
     $this->_saySummary($model->toArray(), $input->getOption('json'));
     return Console::EXIT_SUCCESS;
   }

--- a/src/Command/InputCommand.php
+++ b/src/Command/InputCommand.php
@@ -112,7 +112,7 @@ abstract class InputCommand extends Command {
    * Asks user to fill in missing inputs.
    */
   public function interact(Input $input, Output $output) {
-    $app = $this->getApplication();
+    $app = $this->getConsole();
 
     foreach ($this->_input as $name => $value) {
       if ($value === null) {
@@ -142,10 +142,11 @@ abstract class InputCommand extends Command {
    * Set choices in configure(), or override _getChoices() to lazy-load.
    *
    * @param string $name Name of option to get choices for
+   * @param bool $format Format the choices for output?
    * @return array Map of choice:description pairs if available;
    *  empty array otherwise
    */
-  protected function _getChoices(string $name) : array {
+  protected function _getChoices(string $name, bool $format = false) : array {
     return $this->_choices[$name] ?? [];
   }
 

--- a/src/Command/ShowList.php
+++ b/src/Command/ShowList.php
@@ -9,11 +9,6 @@ declare(strict_types = 1);
 
 namespace Nexcess\Sdk\Cli\Command;
 
-use Nexcess\Sdk\ {
-  ApiException,
-  SdkException
-};
-
 use Nexcess\Sdk\Cli\ {
   Command\Command,
   Command\CommandException,
@@ -98,7 +93,7 @@ abstract class ShowList extends Command {
    * {@inheritDoc}
    */
   protected function _saySummary(array $details, bool $json = false) {
-    $console = $this->getApplication();
+    $console = $this->getConsole();
     $details = $this->_getSummary($details);
 
     if ($json) {
@@ -117,7 +112,7 @@ abstract class ShowList extends Command {
    * @param array $details Items to be displayed
    */
   protected function _sayTable(array $details) {
-    $console = $this->getApplication();
+    $console = $this->getConsole();
 
     if (empty($details)) {
       $details = [[$console->translate('console.no_data') => '']];

--- a/src/Console.php
+++ b/src/Console.php
@@ -9,8 +9,8 @@ declare(strict_types = 1);
 
 namespace Nexcess\Sdk\Cli;
 
-use Exception,
-  SplFileInfo as FileInfo;
+use SplFileInfo as FileInfo;
+
 use Nexcess\Sdk\ {
   Client,
   Sandbox\ResourceHandler,
@@ -21,11 +21,13 @@ use Nexcess\Sdk\ {
   Util\ThermoConfig,
   Util\Util
 };
+
 use Nexcess\Sdk\Cli\ {
   ConsoleException,
   Util\CommandDiscoveryFactory as DiscoveryFactory,
   Util\ErrorHandler
 };
+
 use Symfony\Component\Console\ {
   Application as SymfonyApplication,
   Command\Command as SymfonyCommand,
@@ -102,13 +104,13 @@ class Console extends SymfonyApplication {
   /** @var string Version of application. */
   const VERSION = '0.1-alpha';
 
-  /** @var Guzzle The guzzle http client. */
+  /** @var Client The SDK client. */
   protected $_client;
 
   /** @var Config The SDK configuration object. */
   protected $_config;
 
-  /** @var Handler Application error/exception handler. */
+  /** @var ErrorHandler Application error/exception handler. */
   protected $_error_handler;
 
   /** @var Input Application input object. */
@@ -154,7 +156,7 @@ class Console extends SymfonyApplication {
    * Queries the user and gets response.
    *
    * @param string $message The question to ask
-   * @param string $default A default answer
+   * @param string|null $default A default answer
    * @return string|null The user's response
    * @throws ConsoleException If no QuestionHelper is available
    */
@@ -279,6 +281,9 @@ class Console extends SymfonyApplication {
   /**
    * {@inheritDoc}
    * Overridden to set up the input options needed for bootstrapping.
+   *
+   * symfony/console has wrong annotation for Option::__construct $long
+   * @suppress PhanTypeMismatchArgument
    */
   public function getDefaultInputDefinition() {
     $definition = parent::getDefaultInputDefinition();
@@ -375,7 +380,7 @@ class Console extends SymfonyApplication {
    * {@see Console::sayJson()}
    *
    * @param string $message The message or message key to output
-   * @param array $opts Map of output options:
+   * @param array $options Map of output options:
    *  - bool Console::SAY_OPT_NEWLINE Add a newline at the end?
    *  - int Console::SAY_OPT_OPTIONS {@see OutputInterface::write $options}
    * @return Console $this
@@ -404,7 +409,7 @@ class Console extends SymfonyApplication {
    * this method will attempt to simply echo to stdout.
    *
    * @param mixed $data The data to output
-   * @param array $opts Map of output options:
+   * @param array $options Map of output options:
    *  - bool Console::SAY_OPT_NEWLINE Add a newline at the end?
    *  - int Console::SAY_OPT_OPTIONS {@see OutputInterface::write $options}
    * @return Console $this
@@ -519,6 +524,7 @@ class Console extends SymfonyApplication {
       );
     }
 
+    // @phan-suppress-next-line PhanTypeExpectedObjectOrClassName
     $this->_config = new $profile['fqcn']($profile);
   }
 
@@ -535,8 +541,6 @@ class Console extends SymfonyApplication {
 
   /**
    * Sets up the API Client for console use.
-   *
-   * @param Config $config Sdk configuration object
    */
   protected function _initializeClient() {
     if ($this->_config->get('sandboxed')) {

--- a/src/Util/CommandDiscoveryFactory.php
+++ b/src/Util/CommandDiscoveryFactory.php
@@ -26,7 +26,7 @@ class CommandDiscoveryFactory extends Factory {
   /** @var SymfonyApplication The application we're loading commands for. */
   protected $_app;
 
-  /** @var string[] Map of available command:fqcn pairs. */
+  /** @var array Map of available command:fqcn pairs. */
   protected $_commands = [];
 
   /** @var string Directory to load php files from. */

--- a/src/Util/lang/en_US.json
+++ b/src/Util/lang/en_US.json
@@ -85,7 +85,6 @@
           "status": "Status",
           "temp_domain": "Temp Domain"
         },
-        "timed_out": "<comment>Wait timeout exceeded:</comment> your new Cloud Account is still being set up. <info>Use</info> cloud-account:show {id} <info>to check on its status.</info>",
         "usage": "cloud-account:create --domain cloud.example.com\n  cloud-account:create magento --domain magneto.example.com --install"
       },
       "list": {


### PR DESCRIPTION
fixes https://nexcess.atlassian.net/browse/NSD-12030

includes fixes for about a dozen issues found after upgrading phan. 

notably, methods like `_getEndpoint()` or `retrieve()` are difficult for static analysis because they typehint a base class (`Endpoint` or `Modelable`), but often return a subclass (e.g., `CloudAccount\Endpoint` or `CloudAccount\Entity`/`CloudAccount\Backup`). This leads to false positives when trying to invoke methods defined on the subclass.

the solution in these cases is to `assert()` that the returned object is in fact an instance of the expected subclass ([see example here](https://github.com/nexcess/nexcess-cli/pull/15/files#diff-467408decd0e6ff82e6acf64aeabb5c0R78)). while slightly annoying, this is much better than suppressing the issue (we'd have `@suppress` everywhere, or miss legitimate issues if we suppressed globally)), and should have no runtime impact as `assert` is zero-cost (skipped) with production php.ini settings.

the only issues I've had to suppress globally are due to bugs in phan itself. 
see https://github.com/phan/phan/issues/1143 and https://github.com/phan/phan/issues/2123