### PR TITLE
Add Backup\Show Command

### DIFF
--- a/src/Command/CloudAccount/Backup/GetsBackupChoices.php
+++ b/src/Command/CloudAccount/Backup/GetsBackupChoices.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * @package Nexcess-CLI
+ * @license https://opensource.org/licenses/MIT
+ * @copyright 2018 Nexcess.net, LLC
+ */
+
+declare(strict_types = 1);
+
+namespace Nexcess\Sdk\Cli\Command\CloudAccount\Backup;
+
+use Nexcess\Sdk\Cli\Command\CloudAccount\CloudAccountException;
+
+use Nexcess\Sdk\ {
+  Resource\CloudAccount\Entity as CloudAccount,
+  Resource\CloudAccount\Endpoint,
+  Resource\Readable
+};
+
+trait GetsBackupChoices {
+
+  /**
+   * {@inheritDoc} Command\InputCommand::getInput()
+   */
+  abstract public function getInput(
+    string $name = null,
+    bool $optional = true
+  );
+
+  /**
+   * {@inheritDoc} Command\Command::_getEndpoint()
+   */
+  abstract protected function _getEndpoint(string $endpoint = null) : Readable;
+
+  /** @var array {@inheritDoc} InputCommand::$_choices */
+  protected $_choices = [];
+
+  /**
+   * Gets a map of available cloud accounts.
+   *
+   * @param bool $format Apply formatting?
+   * @return string[] Map of id:description pairs
+   */
+  protected function _getBackupChoices(bool $format = true) : array {
+    if (empty($this->_choices['filename'])) {
+      $id = $this->getInput('cloud_account_id');
+      $endpoint = $this->_getEndpoint();
+      assert($endpoint instanceof Endpoint);
+      $cloudaccount = $endpoint->retrieve($id);
+      assert($cloudaccount instanceof CloudAccount);
+
+      $this->_choices['filename'] = array_column(
+        $endpoint->listBackups($cloudaccount)->toArray(),
+        'filename',
+        'filename'
+      );
+      if (empty($this->_choices['filename'])) {
+        throw new CloudAccountException(
+          CloudAccountException::NO_BACKUP_CHOICES,
+          ['cloud_account_id' => $id, 'domain' => $cloudaccount->get('domain')]
+        );
+      }
+    }
+
+    return $this->_choices['filename'];
+  }
+}

--- a/src/Command/CloudAccount/Backup/GetsBackupChoices.php
+++ b/src/Command/CloudAccount/Backup/GetsBackupChoices.php
@@ -15,7 +15,7 @@ use Nexcess\Sdk\Cli\ {
 };
 
 use Nexcess\Sdk\ {
-  Resource\CloudAccount\Entity as CloudAccount,
+  Resource\CloudAccount\CloudAccount,
   Resource\CloudAccount\Endpoint,
   Resource\Readable
 };

--- a/src/Command/CloudAccount/Backup/GetsBackupChoices.php
+++ b/src/Command/CloudAccount/Backup/GetsBackupChoices.php
@@ -9,7 +9,10 @@ declare(strict_types = 1);
 
 namespace Nexcess\Sdk\Cli\Command\CloudAccount\Backup;
 
-use Nexcess\Sdk\Cli\Command\CloudAccount\CloudAccountException;
+use Nexcess\Sdk\Cli\ {
+  Command\CloudAccount\CloudAccountException,
+  Console
+};
 
 use Nexcess\Sdk\ {
   Resource\CloudAccount\Entity as CloudAccount,
@@ -18,6 +21,11 @@ use Nexcess\Sdk\ {
 };
 
 trait GetsBackupChoices {
+
+  /**
+   * {@inheritDoc} Command\Command::getConsole()
+   */
+  abstract public function getConsole() : Console;
 
   /**
    * {@inheritDoc} Command\InputCommand::getInput()
@@ -62,6 +70,18 @@ trait GetsBackupChoices {
       }
     }
 
-    return $this->_choices['filename'];
+    $choices = $this->_choices['filename'];
+
+    if ($format) {
+      $console = $this->getConsole();
+      foreach ($choices as $filename) {
+        $choices[$filename] = $console->translate(
+          'console.cloud_account.choices.backup',
+          ['filename' => $filename]
+        );
+      }
+    }
+
+    return $choices;
   }
 }

--- a/src/Command/CloudAccount/Backup/Show.php
+++ b/src/Command/CloudAccount/Backup/Show.php
@@ -10,7 +10,7 @@ declare(strict_types = 1);
 namespace Nexcess\Sdk\Cli\Command\CloudAccount\Backup;
 
 use Nexcess\Sdk\ {
-  Resource\CloudAccount\Entity as CloudAccount,
+  Resource\CloudAccount\CloudAccount,
   Resource\CloudAccount\Endpoint,
   Util\Config,
   Util\Util

--- a/src/Command/CloudAccount/Backup/Show.php
+++ b/src/Command/CloudAccount/Backup/Show.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * @package Nexcess-CLI
+ * @license https://opensource.org/licenses/MIT
+ * @copyright 2018 Nexcess.net, LLC
+ */
+
+declare(strict_types = 1);
+
+namespace Nexcess\Sdk\Cli\Command\CloudAccount\Backup;
+
+use Nexcess\Sdk\ {
+  Resource\CloudAccount\Entity as CloudAccount,
+  Resource\CloudAccount\Endpoint,
+  Util\Config,
+  Util\Util
+};
+
+use Nexcess\Sdk\Cli\ {
+  Command\CloudAccount\Backup\GetsBackupChoices,
+  Command\CloudAccount\GetsCloudAccountChoices,
+  Command\InputCommand,
+  Console
+};
+
+use Symfony\Component\Console\ {
+  Input\InputInterface as Input,
+  Input\InputOption as Opt,
+  Output\OutputInterface as Output
+};
+
+/**
+ * Creates a new Cloud Account.
+ */
+class Show extends InputCommand {
+  use GetsCloudAccountChoices,
+    GetsBackupChoices;
+
+  /** {@inheritDoc} */
+  const ENDPOINT = Endpoint::class;
+
+  /** {@inheritDoc} */
+  const NAME = 'cloud-account:backup:show';
+
+  /** {@inheritDoc} */
+  const INPUTS = [
+    'cloud_account_id' => Util::FILTER_INT,
+    'filename' => Util::FILTER_STRING
+  ];
+
+  /** {@inheritDoc} */
+  const OPTS = [
+    'cloud-account-id|c' => [OPT::VALUE_REQUIRED],
+    'filename|f' => [Opt::VALUE_REQUIRED]
+  ];
+
+  /** {@inheritDoc} */
+  const RESTRICT_TO = [Config::COMPANY_NEXCESS];
+
+  /** {@inheritDoc} */
+  const SUMMARY_KEYS = [
+    'filename',
+    'type',
+    'filesize',
+    'filedate',
+    'complete'
+  ];
+
+  /**
+   * {@inheritDoc}
+   */
+  public function execute(Input $input, Output $output) {
+    $endpoint = $this->_getEndpoint();
+    assert($endpoint instanceof Endpoint);
+    $cloudaccount_id = $this->getInput('cloud_account_id');
+    $cloudaccount = $endpoint->retrieve($cloudaccount_id);
+    assert($cloudaccount instanceof CloudAccount);
+    $backup = $endpoint
+      ->retrieveBackup($cloudaccount, $this->getInput('filename'))
+      ->toArray();
+
+    $this->_saySummary($backup, $input->getOption('json'));
+    $this->getConsole()->say(
+      $this->getPhrase(
+        'how_to_download',
+        [
+          'cloud_account_id' => $cloudaccount_id,
+          'filename' => $backup['filename']
+        ]
+      )
+    );
+
+    return Console::EXIT_SUCCESS;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function _getChoices(string $name, bool $format = true) : array {
+    switch ($name) {
+      case 'cloud_account_id':
+        return $this->_getCloudAccountChoices($format);
+      case 'filename':
+        return $this->_getBackupChoices($format);
+      default:
+        return parent::_getChoices($name, $format);
+    }
+  }
+}

--- a/src/Command/CloudAccount/CloudAccountException.php
+++ b/src/Command/CloudAccount/CloudAccountException.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @package Nexcess-CLI
+ * @license https://opensource.org/licenses/MIT
+ * @copyright 2018 Nexcess.net, LLC
+ */
+
+declare(strict_types = 1);
+
+namespace Nexcess\Sdk\Cli\Command\CloudAccount;
+
+use Nexcess\Sdk\Exception;
+
+class CloudAccountException extends Exception {
+
+  /** @var int No cloud accounts to choose from. */
+  const NO_CLOUD_ACCOUNT_CHOICES = 1;
+
+  /** @var int No cloud account backups to choose from. */
+  const NO_BACKUP_CHOICES = 2;
+
+  /** {@inheritDoc} */
+  const INFO = [
+    self::NO_BACKUP_CHOICES =>
+      ['message' => 'console.cloud_account.exception.no_backup_choices'],
+    self::NO_CLOUD_ACCOUNT_CHOICES =>
+      ['message' => 'console.cloud_account.exception.no_cloud_account_choices']
+  ];
+}

--- a/src/Command/CloudAccount/GetsCloudAccountChoices.php
+++ b/src/Command/CloudAccount/GetsCloudAccountChoices.php
@@ -9,11 +9,19 @@ declare(strict_types = 1);
 
 namespace Nexcess\Sdk\Cli\Command\CloudAccount;
 
-use Nexcess\Sdk\Cli\Command\CloudAccount\CloudAccountException;
+use Nexcess\Sdk\Cli\Console;
 
-use Nexcess\Sdk\Resource\Readable;
+use Nexcess\Sdk\ {
+  Resource\CloudAccount\Endpoint,
+  Resource\Readable
+};
 
 trait GetsCloudAccountChoices {
+
+  /**
+   * {@inheritDoc} Command\Command::getConsole()
+   */
+  abstract public function getConsole() : Console;
 
   /**
    * {@inheritDoc} Command\Command::_getEndpoint()
@@ -30,23 +38,35 @@ trait GetsCloudAccountChoices {
    * @return string[] Map of id:description pairs
    */
   protected function _getCloudAccountChoices(bool $format = true) : array {
-    if (empty($this->_choices['cloud_account_id'])) {
-      $choices = array_column(
-        $this->_getEndpoint()->list()->toArray(),
+    if (empty($this->_choices['cloud_account'])) {
+      $this->_choices['cloud_account'] = array_column(
+        $this->_getEndpoint(Endpoint::class)->list()->toArray(),
         null,
         'id'
       );
-      if (empty($choices)) {
+      if (empty($this->_choices['cloud_account'])) {
         throw new CloudAccountException(
           CloudAccountException::NO_CLOUD_ACCOUNT_CHOICES
         );
       }
-
-      foreach ($choices as $id => $cloudaccount) {
-        $this->_choices['cloud_account_id'][$id] =
-          "{$cloudaccount['ip']} {$cloudaccount['domain']}";
-      }
     }
-    return $this->_choices['cloud_account_id'];
+
+    $choices = $this->_choices['cloud_account'];
+
+    if ($format) {
+      $console = $this->getConsole();
+      foreach ($choices as $id => $cloudaccount) {
+        $choices[$id] = $console->translate(
+          'console.cloud_account.choices.cloud_account',
+          $cloudaccount
+        );
+      }
+      return $choices;
+    }
+
+    foreach ($choices as $id => $cloudaccount) {
+      $choices[$id] = $cloudaccount['domain'];
+    }
+    return $choices;
   }
 }

--- a/src/Command/CloudAccount/GetsCloudAccountChoices.php
+++ b/src/Command/CloudAccount/GetsCloudAccountChoices.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @package Nexcess-CLI
+ * @license https://opensource.org/licenses/MIT
+ * @copyright 2018 Nexcess.net, LLC
+ */
+
+declare(strict_types = 1);
+
+namespace Nexcess\Sdk\Cli\Command\CloudAccount;
+
+use Nexcess\Sdk\Cli\Command\CloudAccount\CloudAccountException;
+
+use Nexcess\Sdk\Resource\Readable;
+
+trait GetsCloudAccountChoices {
+
+  /**
+   * {@inheritDoc} Command\Command::_getEndpoint()
+   */
+  abstract protected function _getEndpoint(string $endpoint = null) : Readable;
+
+  /** @var array {@inheritDoc} InputCommand::$_choices */
+  protected $_choices = [];
+
+  /**
+   * Gets a map of available cloud accounts.
+   *
+   * @param bool $format Apply formatting?
+   * @return string[] Map of id:description pairs
+   */
+  protected function _getCloudAccountChoices(bool $format = true) : array {
+    if (empty($this->_choices['cloud_account_id'])) {
+      $choices = array_column(
+        $this->_getEndpoint()->list()->toArray(),
+        null,
+        'id'
+      );
+      if (empty($choices)) {
+        throw new CloudAccountException(
+          CloudAccountException::NO_CLOUD_ACCOUNT_CHOICES
+        );
+      }
+
+      foreach ($choices as $id => $cloudaccount) {
+        $this->_choices['cloud_account_id'][$id] =
+          "{$cloudaccount['ip']} {$cloudaccount['domain']}";
+      }
+    }
+    return $this->_choices['cloud_account_id'];
+  }
+}

--- a/src/Command/Command.php
+++ b/src/Command/Command.php
@@ -175,7 +175,7 @@ abstract class Command extends SymfonyCommand {
       $long = array_shift($name);
       $short = array_shift($name);
       $mode = array_shift($opt) ?? Opt::VALUE_OPTIONAL;
-      $desc = $this->getPhrase("opt_{$long}");
+      $desc = $this->getPhrase('opt_' . strtr($long, ['-' => '_']));
       $default = array_shift($opt);
 
       $this->addOption($long, $short, $mode, $desc, $default);

--- a/src/Util/lang/en_US.json
+++ b/src/Util/lang/en_US.json
@@ -12,18 +12,6 @@
     "banner": "Command Line Interface for the Nexcess.net / Thermo.io API Client\nⓒ 2018 Nexcess.net, LLC\n",
     "cloud_account": {
       "backup" : {
-        "delete": {
-          "deleting": "<info>Deleting</info> {filename}",
-          "done": "Done",
-          "help": "Delete a specific backup from the system",
-          "usage": "cloud-account:backup:delete --filename file_name.tgz --cloud-account-id 1234"
-        },
-        "download": {
-          "done": "Done",
-          "downloading" : "<info>Downloading</info> {filename} <info>to</info> {download_path}",
-          "help": "Download a specific backup",
-          "usage": "cloud-account:backup:download -d /path/to/place/download/in -f file_name.tgz -c 1234"
-        },
         "create": {
           "backup_complete": "Backup complete.\n<info>To download this backup, use:</info>\ncloud-account:backup:download --cloud-account-id {cloud_account_id} \\\n  --filename '{filename}'",
           "backup_started": "<info>To check on the status of this Backup, use:</info>\ncloud-account:backup:show --cloud-account-id {cloud_account_id} \\\n  --filename '{filename}'",
@@ -50,6 +38,18 @@
           },
           "usage": "cloud-account:backup:create --cloud-account-id 1234\n  cloud-account:backup:create --cloud-account-id 1234 --download /home/You/Downloads",
           "waiting": "Waiting for Backup to complete..."
+        },
+        "delete": {
+          "deleting": "<info>Deleting</info> {filename}",
+          "done": "Done",
+          "help": "Delete a specific backup from the system",
+          "usage": "cloud-account:backup:delete --filename file_name.tgz --cloud-account-id 1234"
+        },
+        "download": {
+          "done": "Done",
+          "downloading" : "<info>Downloading</info> {filename} <info>to</info> {download_path}",
+          "help": "Download a specific backup",
+          "usage": "cloud-account:backup:download -d /path/to/place/download/in -f file_name.tgz -c 1234"
         },
         "list": {
           "complete": "Complete",
@@ -81,6 +81,10 @@
           "summary_title": "Cloud Account Backup",
           "usage": "cloud-account:backup:show --cloud-account-id 1234 --filename example.com+full-single-date.time.tgz"
         }
+      },
+      "choices": {
+        "backup": "<question>{filename}</question>",
+        "cloud_account": "<question>{domain}</question> ({ip})"
       },
       "create": {
         "app_desc": "<question>{app}</question>",

--- a/src/Util/lang/en_US.json
+++ b/src/Util/lang/en_US.json
@@ -12,35 +12,17 @@
     "banner": "Command Line Interface for the Nexcess.net / Thermo.io API Client\nⓒ 2018 Nexcess.net, LLC\n",
     "cloud_account": {
       "backup" : {
+        "delete": {
+          "deleting": "<info>Deleting</info> {filename}",
+          "done": "Done",
+          "help": "Delete a specific backup from the system",
+          "usage": "cloud-account:backup:delete --filename file_name.tgz --cloud-account-id 1234"
+        },
         "download": {
           "done": "Done",
           "downloading" : "<info>Downloading</info> {filename} <info>to</info> {download_path}",
           "help": "Download a specific backup",
           "usage": "cloud-account:backup:download -d /path/to/place/download/in -f file_name.tgz -c 1234"
-        },
-        "list": {
-          "complete": "Complete",
-          "desc" : "List all backups for a given cloud account.",
-          "help": "Outputs a list of all the backups for a given cloud account",
-          "filedate": "File Date",
-          "filename": "File Name",
-          "filesize": "File Size",
-          "opt_cloud_account_id": "Cloud Account ID",
-          "summary_title": "Backups",
-          "usage": "cloud-account:backup:list --cloud-account-id 1234",
-          "done": "Done"
-        },
-        "delete": {
-          "done": "Done",
-          "deleting": "<info>Deleting</info> {filename}",
-          "help": "Delete a specific backup from the system",
-          "usage": "cloud-account:backup:delete --filename file_name.tgz --cloud-account-id 1234"
-        },
-        "delete": {
-          "done": "Done",
-          "deleting": "<info>Deleting</info> {filename}",
-          "help": "Delete a specific backup from the system",
-          "usage": "cloud-account:backup:delete --filename file_name.tgz --cloud-account-id 1234"
         },
         "create": {
           "backup_complete": "Backup complete.\n<info>To download this backup, use:</info>\ncloud-account:backup:download --cloud-account-id {cloud_account_id} \\\n  --filename '{filename}'",
@@ -68,6 +50,36 @@
           },
           "usage": "cloud-account:backup:create --cloud-account-id 1234\n  cloud-account:backup:create --cloud-account-id 1234 --download /home/You/Downloads",
           "waiting": "Waiting for Backup to complete..."
+        },
+        "list": {
+          "complete": "Complete",
+          "desc" : "List all backups for a given cloud account.",
+          "help": "Outputs a list of all the backups for a given cloud account",
+          "filedate": "File Date",
+          "filename": "File Name",
+          "filesize": "File Size",
+          "opt_cloud_account_id": "Cloud Account ID",
+          "summary_title": "Backups",
+          "usage": "cloud-account:backup:list --cloud-account-id 1234",
+          "done": "Done"
+        },
+        "show": {
+          "choose_cloud_account_id": "Choose which Cloud Account you want to select a Backup from:",
+          "choose_filename": "Choose a Backup to view:",
+          "desc": "Show details of a cloud account backup",
+          "help": "Gets information about a given cloud account backup. The --cloud-account-id and --filename may be omitted to choose from a list.",
+          "how_to_download": "<info>To download this backup, use</info> cloud-account:backup:download \\\n  -c {cloud_account_id} \\\n  -f {filename} \\\n  --download-path TARGET_DOWNLOAD_DIRECTORY",
+          "opt_cloud_account_id": "Cloud Account ID",
+          "opt_filename": "Cloud Account Backup Filename",
+          "summary_key" : {
+            "complete": "Complete",
+            "filedate": "Backup Started On",
+            "filename": "File Name",
+            "filesize": "File Size",
+            "type": "Type"
+          },
+          "summary_title": "Cloud Account Backup",
+          "usage": "cloud-account:backup:show --cloud-account-id 1234 --filename example.com+full-single-date.time.tgz"
         }
       },
       "create": {
@@ -98,6 +110,10 @@
           "temp_domain": "Temp Domain"
         },
         "usage": "cloud-account:create --domain cloud.example.com\n  cloud-account:create magento --domain magneto.example.com --install"
+      },
+      "exception": {
+        "no_backup_choices": "No backups are available to choose from on {domain} (use `cloud-account:backup:create -c {cloud_account_id}` to create one)",
+        "no_cloud_account_choices": "No cloud accounts are available to choose from (use `cloud-account:create` to create one)"
       },
       "list": {
         "desc": "Lists your Cloud Accounts",


### PR DESCRIPTION
fixes https://nexcess.atlassian.net/browse/NSD-12814

```
nexcess-cli$ bin/nexcess-cli help cloud-account:backup:show
Nexcess-CLI 0.1-alpha
Command Line Interface for the Nexcess.net / Thermo.io API Client
ⓒ 2018 Nexcess.net, LLC

Description:
  Show details of a cloud account backup

Usage:
  cloud-account:backup:show [options]
  cloud-account:backup:show --cloud-account-id 1234 --filename example.com+full-single-date.time.tgz

Options:
  -c, --cloud-account-id=CLOUD-ACCOUNT-ID  Cloud Account ID
  -f, --filename=FILENAME                  Cloud Account Backup Filename
  -h, --help                               Display this help message
  -q, --quiet                              Do not output any message
  -V, --version                            Display this application version
      --ansi                               Force ANSI output
      --no-ansi                            Disable ANSI output
  -n, --no-interaction                     Do not ask any interactive question
      --api-token=API-TOKEN                Your API Token (log in to your portal to create one)
  -j, --json                               Display command output as json? (this does not affect interactive output; see --no-interaction)
      --profile=PROFILE                    Filename of the user profile to load; or one of nexcess|thermo to use the default profiles
      --sandboxed                          Do not send any API requests
      --wait                               Wait for long-running commands to complete (this can block for a long time)?
  -v|vv|vvv, --verbose                     Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Help:
  Gets information about a given cloud account backup. The --cloud-account-id and --filename may be omitted to choose from a list.
```
https://s3.amazonaws.com/uploads.hipchat.com/7453/2607689/mC0SYJXhcbomNBq/cli-show-backups.mp4