### PR TITLE
Make Opts

### DIFF
--- a/src/Command/CloudAccount/Backup/Create.php
+++ b/src/Command/CloudAccount/Backup/Create.php
@@ -20,7 +20,7 @@ use Nexcess\Sdk\ {
 
 use Nexcess\Sdk\Cli\ {
   Command\CloudAccount\GetsCloudAccountChoices,
-  Command\Create as CreateCommand,
+  Command\InputCommand,
   Console
 };
 
@@ -33,11 +33,8 @@ use Symfony\Component\Console\ {
 /**
  * Creates a new Cloud Account.
  */
-class Create extends CreateCommand {
+class Create extends InputCommand {
   use GetsCloudAccountChoices;
-
-  /** {@inheritDoc} */
-  const ARGS = [];
 
   /** {@inheritDoc} */
   const ENDPOINT = Endpoint::class;

--- a/src/Command/CloudAccount/Backup/Delete.php
+++ b/src/Command/CloudAccount/Backup/Delete.php
@@ -37,9 +37,6 @@ class Delete extends InputCommand {
     GetsBackupChoices;
 
   /** {@inheritDoc} */
-  const ARGS = [];
-
-  /** {@inheritDoc} */
   const ENDPOINT = Endpoint::class;
 
   /** {@inheritDoc} */

--- a/src/Command/CloudAccount/Backup/Download.php
+++ b/src/Command/CloudAccount/Backup/Download.php
@@ -37,9 +37,6 @@ class Download extends InputCommand {
     GetsBackupChoices;
 
   /** {@inheritDoc} */
-  const ARGS = [];
-
-  /** {@inheritDoc} */
   const ENDPOINT = Endpoint::class;
 
   /** {@inheritDoc} */

--- a/src/Command/CloudAccount/Backup/ShowList.php
+++ b/src/Command/CloudAccount/Backup/ShowList.php
@@ -43,10 +43,8 @@ class ShowList extends ShowListCommand {
   const SUMMARY_KEYS = ['filename', 'filedate', 'complete', 'filesize'];
 
   /** {@inheritDoc} */
-  const OPTS = ['cloud-account-id' => [Opt::VALUE_REQUIRED]];
-
-  /** {@inheritDoc} */
-  const ARGS = [];
+  const OPTS = ShowListCommand::OPTS +
+    ['cloud-account-id' => [Opt::VALUE_REQUIRED]];
 
   /** {@inheritDoc} */
   public function execute(Input $input, Output $output) {

--- a/src/Command/CloudAccount/Create.php
+++ b/src/Command/CloudAccount/Create.php
@@ -19,7 +19,6 @@ use Nexcess\Sdk\Cli\ {
   Command\Create as CreateCommand
 };
 use Symfony\Component\Console\ {
-  Input\InputArgument as Arg,
   Input\InputInterface as Input,
   Input\InputOption as Opt,
   Output\OutputInterface as Output
@@ -30,9 +29,6 @@ use Symfony\Component\Console\ {
  */
 class Create extends CreateCommand {
   use GetsPackageChoices;
-
-  /** {@inheritDoc} */
-  const ARGS = ['app' => [Arg::OPTIONAL]];
 
   /** {@inheritDoc} */
   const ENDPOINT = Endpoint::class;
@@ -51,11 +47,12 @@ class Create extends CreateCommand {
 
   /** {@inheritDoc} */
   const OPTS = [
-    'app-id' => [OPT::VALUE_REQUIRED],
-    'cloud-id' => [OPT::VALUE_REQUIRED],
-    'domain' => [OPT::VALUE_REQUIRED],
-    'install-app' => [OPT::VALUE_NONE],
-    'package-id' => [OPT::VALUE_REQUIRED]
+    'app' => [Opt::VALUE_REQUIRED],
+    'app-id' => [Opt::VALUE_REQUIRED],
+    'cloud-id' => [Opt::VALUE_REQUIRED],
+    'domain' => [Opt::VALUE_REQUIRED],
+    'install-app' => [Opt::VALUE_NONE],
+    'package-id' => [Opt::VALUE_REQUIRED]
   ];
 
   /** {@inheritDoc} */
@@ -67,7 +64,7 @@ class Create extends CreateCommand {
   public function initialize(Input $input, Output $output) {
     parent::initialize($input, $output);
 
-    $app = $input->getArgument('app');
+    $app = $input->getOption('app');
     if ($app !== null) {
       $this->_lookupChoice('app_id', $app);
     }

--- a/src/Command/CloudAccount/Show.php
+++ b/src/Command/CloudAccount/Show.php
@@ -40,7 +40,7 @@ class Show extends ShowCommand {
   const NAME = 'cloud-account:show';
 
   /** {@inheritDoc} */
-  const OPTS = [
+  const OPTS = ShowCommand::OPTS + [
     'domain' => [OPT::VALUE_REQUIRED],
     'ip' => [Opt::VALUE_REQUIRED]
   ];

--- a/src/Command/Show.php
+++ b/src/Command/Show.php
@@ -15,8 +15,8 @@ use Nexcess\Sdk\Cli\ {
   Console
 };
 use Symfony\Component\Console\ {
-  Input\InputArgument as Arg,
   Input\InputInterface as Input,
+  Input\InputOption as Opt,
   Output\OutputInterface as Output
 };
 
@@ -26,7 +26,7 @@ use Symfony\Component\Console\ {
 abstract class Show extends InputCommand {
 
   /** {@inheritDoc} */
-  const ARGS = ['id' => [Arg::OPTIONAL]];
+  const OPTS = ['id' => [Opt::VALUE_REQUIRED]];
 
   /** {@inheritDoc} */
   const INPUTS = ['id' => Util::FILTER_INT];

--- a/src/Command/ShowList.php
+++ b/src/Command/ShowList.php
@@ -16,8 +16,8 @@ use Nexcess\Sdk\Cli\ {
 };
 
 use Symfony\Component\Console\ {
-  Input\InputArgument as Arg,
   Input\InputInterface as Input,
+  Input\InputOption as Opt,
   Output\OutputInterface as Output,
   Helper\TableStyle,
   Helper\Table
@@ -29,7 +29,7 @@ use Symfony\Component\Console\ {
 abstract class ShowList extends Command {
 
   /** {@inheritDoc} */
-  const ARGS = ['filter' => [Arg::OPTIONAL | Arg::IS_ARRAY]];
+  const OPTS = ['filter' => [Opt::VALUE_REQUIRED | Opt::VALUE_IS_ARRAY]];
 
   /** @var array List filter parsed from args. */
   protected $_filter = [];
@@ -39,18 +39,16 @@ abstract class ShowList extends Command {
    */
   public function initialize(Input $input, Output $output) {
     // collect list filter params
-    if ($input->hasArgument('filter')) {
-      foreach ($input->getArgument('filter') as $filter) {
-        if (substr_count($filter, ':') !== 1) {
-          throw new CommandException(
-            CommandException::INVALID_LIST_FILTER,
-            ['filter' => $filter]
-          );
-        }
-
-        [$key, $value] = explode(':', $filter);
-        $this->_filter[$key] = $value;
+    foreach ($input->getOption('filter') as $filter) {
+      if (substr_count($filter, ':') !== 1) {
+        throw new CommandException(
+          CommandException::INVALID_LIST_FILTER,
+          ['filter' => $filter]
+        );
       }
+
+      [$key, $value] = explode(':', $filter);
+      $this->_filter[$key] = $value;
     }
   }
 

--- a/src/Util/lang/en_US.json
+++ b/src/Util/lang/en_US.json
@@ -100,17 +100,17 @@
       },
       "create": {
         "app_desc": "<question> {app} </question>",
-        "arg_app": "Application Environment name (used for app_id lookup)",
         "ask_domain": "What Domain Name do you want to use for your Cloud Account?",
         "choose_app_id": "Select an Application Environment for your Cloud Account:",
         "choose_cloud_id": "Choose which Cloud you want your Cloud Account to be hosted on:",
         "choose_package_id": "Choose a Service Level for your Cloud Account:",
         "cloud_desc": "<question> {location} </question> ({location_code})",
-        "created": "\nYour new Cloud Account has been created. <info>Use</info> cloud-account:show {id} <info>to check on its status!</info>",
+        "created": "\nYour new Cloud Account has been created. <info>Use</info> cloud-account:show --id {id} <info>to check on its status!</info>",
         "creating": "Your new Cloud Account is being created. <info>This may take a few moments…</info>",
         "desc": "Creates a new Cloud Account",
         "failed": "<error>Creating your new Cloud Account failed.</error> Please open a support ticket.",
         "help": "Any option may be omitted and you will be prompted to choose from a menu.\nProviding an application name (e.g., 'magento') will select that application for you.",
+        "opt_app": "Application Environment name (used for app_id lookup)",
         "opt_app_id": "Application Environment ID",
         "opt_cloud_id": "Cloud location ID",
         "opt_domain": "Domain Name",
@@ -125,21 +125,21 @@
           "state": "Cloud Account State",
           "temp_domain": "Temp Domain"
         },
-        "usage": "cloud-account:create --domain cloud.example.com\n  cloud-account:create magento --domain magneto.example.com --install"
+        "usage": "cloud-account:create --domain cloud.example.com\n  cloud-account:create --app magento --domain magneto.example.com --install-app"
       },
       "list": {
         "desc": "Lists your Cloud Accounts",
         "help": "You may proivde one or more filters in the form 'filter:value'.",
         "summary_item": "  #{id}: {domain} ({ip})",
         "summary_title": "Cloud Accounts:",
-        "usage": "cloud-account:list\n  cloud-account:list service.status:active"
+        "usage": "cloud-account:list\n  cloud-account:list --filter service.status:enabled"
       },
       "show": {
-        "arg_id": "Cloud Account Service ID",
         "choose_id": "Select a Cloud Account to view:",
         "desc": "Shows details of an existing Cloud Account",
         "help": "Provide a service id, or use the --domain or --ip options to look up the desired service.",
         "opt_domain": "Cloud Account Domain Name (used for service_id lookup)",
+        "opt_id": "Cloud Account Service ID",
         "opt_ip": "Cloud Account IP Address (used for service_id lookup)",
         "summary_app": "#{app_id} {identity}",
         "summary_key": {
@@ -159,7 +159,7 @@
         "summary_location": "#{cloud_id} {identity}",
         "summary_service": "#{service_id} {identity}",
         "summary_title": "Cloud Account Details:",
-        "usage": "cloud-account:show 12345\n  cloud-account:show --domain cloud.example.com"
+        "usage": "cloud-account:show --id 12345\n  cloud-account:show --domain cloud.example.com"
       }
     },
     "command": {

--- a/tests/Command/ListTestCase.php
+++ b/tests/Command/ListTestCase.php
@@ -29,7 +29,7 @@ abstract class ListTestCase extends CommandTestCase {
   public function runProvider() : array {
     return [
       [
-        ['filter' => ['foobar']],
+        ['--filter' => ['foobar']],
         [],
         [],
         new CommandException(CommandException::INVALID_LIST_FILTER)


### PR DESCRIPTION
fixes https://nexcess.atlassian.net/browse/NSD-13207

In the future, commands should favor defining cli options (`--foo opt`) instead of arguments (`foo argument`).

Note that, in the case that both a command and its parent defines `OPTS`, the child class' definition _replaces_ the parent's. This has always been true, but I expect we may now run into more cases where it is not desirable/expected.

In such cases, the child command must explicitly include the parent's OPTS:
```php
class ParentCommand {

  // has --foo option
  const OPTS = [['foo' => [Opt::VALUE_REQUIRED]]];
}

class ReplacesParentOpts extends ParentCommand {

  // has ONLY --bar option
  const OPTS = [['bar' => [Opt::VALUE_REQUIRED]]];
}

class AddsToParentOpts extends ParentCommand {

  // has BOTH --foo and --bar options
  const OPTS = ParentCommand::OPTS + [['bar' => [Opt::VALUE_REQUIRED]]];
}
```
Adding `OPTS` is **always** recommended, except in cases where the specific intent is to override.

Note this does not apply to options defined by the _application_ (the `Console` class), such as `--help`, `--quiet`, `--api-token`, `--profile`, `--json`, and so forth: these options are always available.